### PR TITLE
Add nuclio example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repo contains a simple app and steps for deploying it to several popular se
 * [OpenFaas](https://www.openfaas.com/)
 * [OpenWhisk](http://openwhisk.incubator.apache.org)
 * [Fn](http://fnproject.io)
+* [Nuclio](https://github.com/nuclio/nuclio)
 
 ## Usage
 See the README's within each frameworks directory.

--- a/nuclio/README.md
+++ b/nuclio/README.md
@@ -1,0 +1,25 @@
+# Template for deploying an app to nuclio
+[Nuclio](https://github.com/nuclio/nuclio)
+
+## Pre-reqs
+* Kube cluster with nuclio installed
+* kubectl and [nuctl](https://github.com/nuclio/nuclio/releases) installed
+* Prepared private docker registry with configured credentials secret. Nuclio need to push docker images into a repository. [see this](https://github.com/nuclio/nuclio/blob/master/docs/setup/k8s/getting-started-k8s.md#install-nuclio)
+
+## Deploy to Nuclio
+> Note: If you are using Docker Hub, the URL here includes your username - `docker.io/<username>`.
+```
+nuctl deploy helloworld -n nuclio -p https://raw.githubusercontent.com/appvia/serverless-kube/master/nuclio/app.py --registry <URL>
+```
+
+## Call the function from the CLI
+```
+$ nuctl invoke -n nuclio helloworld
+```
+
+## Call the function using http
+```
+$ kubectl port-forward --namespace nuclio $(kubectl get pod --namespace nuclio --selector="nuclio.io/app=functionres,nuclio.io/class=function,nuclio.io/function-name=helloworld,nuclio.io/function-version=latest,nuclio.io/project-name=default" --output jsonpath='{.items[0].metadata.name}') 8080:8080 &
+
+$ curl localhost:8080
+```

--- a/nuclio/app.py
+++ b/nuclio/app.py
@@ -1,0 +1,9 @@
+def handler(context, event):
+    response_body = f'Got {event.method} to {event.path} with "{event.body}"'
+
+    context.logger.debug('This is a debug level message')
+
+    return context.Response(body=response_body,
+                            headers=None,
+                            content_type='text/plain',
+                            status_code=200)    


### PR DESCRIPTION
Hi,

I like this overview of serverless frameworks for kubernetes with small examples. So I created a example for nuclio, which you can add to the list of examples if you want.